### PR TITLE
Fix command name 2

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Storage;
 
 class InstallCommand extends Command
 {
-    protected $signature = 'sab-hero-estimator:install
+    protected $signature = 'sabhero-estimator:install
                             {--force : Force overwrite of existing files (config, migrations, etc.)}
                             {--fresh : Remove old estimator migrations before publishing new ones}';
 
@@ -70,27 +70,9 @@ class InstallCommand extends Command
             });
         }
 
-        // Publish assets (images) to configured disk
-        $this->components->task('Publishing assets to configured disk', function () {
-            return $this->publishImagesToDisk();
-        });
-
         $this->components->info('SAB Hero Estimator installed successfully!');
 
-        // Display next steps
-        $this->displayNextSteps();
-
         return self::SUCCESS;
-    }
-
-    protected function displayNextSteps(): void
-    {
-        $this->components->bulletList([
-            'Add package views to your Tailwind config: <fg=yellow>\'./vendor/fuelviews/laravel-sabhero-estimator/resources/**/*.blade.php\'</fg>',
-            'Add the Livewire component to your blade template: <fg=yellow>@livewire(\'estimator::project-estimator\')</fg>',
-            'Register the Filament plugin to access admin resources',
-            'Review the published config file: <fg=yellow>config/sabhero-estimator.php</fg>',
-        ]);
     }
 
     /**

--- a/src/SabHeroEstimatorServiceProvider.php
+++ b/src/SabHeroEstimatorServiceProvider.php
@@ -14,7 +14,7 @@ class SabHeroEstimatorServiceProvider extends PackageServiceProvider
     public function configurePackage(Package $package): void
     {
         $package
-            ->name('laravel-sabhero-estimator')
+            ->name('sabhero-estimator')
             ->hasConfigFile()
             ->hasViews()
             ->hasMigrations([
@@ -27,7 +27,6 @@ class SabHeroEstimatorServiceProvider extends PackageServiceProvider
                 'populate_estimator_rates_defaults',
                 'populate_estimator_multipliers_defaults',
                 'populate_estimator_settings_defaults',
-                'fix_estimator_multiplier_image_paths',
             ])
             ->hasCommands([
                 InstallCommand::class,


### PR DESCRIPTION
Updates the package name and refines the migration list in the `SabHeroEstimatorServiceProvider` class. 

**Changes:**
1. The package name in `SabHeroEstimatorServiceProvider` is changed from `'laravel-sabhero-estimator'` to `'sabhero-estimator'`.
2. The migration `'fix_estimator_multiplier_image_paths'` is removed from the list of migrations.