### PR TITLE
Rename install command class and signature to sabhero-estimator for consistency, update related references and documentation, and add asset publishing to the install process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ composer require fuelviews/laravel-sabhero-estimator
 ### 2. Run Installation Command
 
 ```bash
-php artisan sab-hero-estimator:install
+php artisan sabhero-estimator:install
 ```
 
 This command will:
@@ -71,19 +71,19 @@ Add the Livewire component to any Blade template:
 ### Clean Installation
 Remove old migrations before installing:
 ```bash
-php artisan sab-hero-estimator:install --fresh
+php artisan sabhero-estimator:install --fresh
 ```
 
 ### Force Overwrite
 Overwrite existing files:
 ```bash
-php artisan sab-hero-estimator:install --force
+php artisan sabhero-estimator:install --force
 ```
 
 ### Silent Installation
 For automated deployments:
 ```bash
-php artisan sab-hero-estimator:install --fresh --force --no-interaction
+php artisan sabhero-estimator:install --fresh --force --no-interaction
 ```
 
 ### Manual Installation
@@ -216,7 +216,7 @@ php artisan vendor:publish --tag="sabhero-estimator-assets" --force
 php artisan migrate:status | grep estimator
 
 # Clean reinstall
-php artisan sab-hero-estimator:install --fresh --force
+php artisan sabhero-estimator:install --fresh --force
 ```
 
 ### Table Not Found
@@ -226,7 +226,7 @@ php artisan sab-hero-estimator:install --fresh --force
 php artisan tinker --execute="DB::table('estimator_rates')->count()"
 
 # If not found, reinstall
-php artisan sab-hero-estimator:install --fresh
+php artisan sabhero-estimator:install --fresh
 ```
 
 ## Advanced Topics

--- a/src/Commands/SabHeroEstimatorInstallCommand.php
+++ b/src/Commands/SabHeroEstimatorInstallCommand.php
@@ -6,11 +6,11 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 
-class InstallCommand extends Command
+class SabHeroEstimatorInstallCommand extends Command
 {
     protected $signature = 'sabhero-estimator:install
-                            {--force : Force overwrite of existing files (config, migrations, etc.)}
-                            {--fresh : Remove old estimator migrations before publishing new ones}';
+                            {--force : Force overwrite of existing files}
+                            {--fresh : Remove old estimator migrations}';
 
     protected $description = 'Install the Sab Hero Estimator package and optionally clean up old migrations';
 
@@ -69,6 +69,11 @@ class InstallCommand extends Command
                 return $this->callSilent('migrate') === 0;
             });
         }
+
+        // Publish assets (images) to configured disk
+        $this->components->task('Publishing assets to configured disk', function () {
+            return $this->publishImagesToDisk();
+        });
 
         $this->components->info('SAB Hero Estimator installed successfully!');
 

--- a/src/Filament/EstimatorPlugin.php
+++ b/src/Filament/EstimatorPlugin.php
@@ -18,7 +18,7 @@ class EstimatorPlugin implements Plugin
 
     public function getId(): string
     {
-        return 'sab-hero-estimator';
+        return 'sabhero-estimator';
     }
 
     public function register(Panel $panel): void

--- a/src/SabHeroEstimatorServiceProvider.php
+++ b/src/SabHeroEstimatorServiceProvider.php
@@ -5,7 +5,6 @@ namespace Fuelviews\SabHeroEstimator;
 use Fuelviews\SabHeroEstimator\Commands\SabHeroEstimatorInstallCommand;
 use Fuelviews\SabHeroEstimator\Livewire\ProjectEstimator;
 use Livewire\Livewire;
-use Spatie\LaravelPackageTools\Commands\InstallCommand as SpatieInstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 

--- a/src/SabHeroEstimatorServiceProvider.php
+++ b/src/SabHeroEstimatorServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Fuelviews\SabHeroEstimator;
 
-use Fuelviews\SabHeroEstimator\Commands\InstallCommand;
+use Fuelviews\SabHeroEstimator\Commands\SabHeroEstimatorInstallCommand;
 use Fuelviews\SabHeroEstimator\Livewire\ProjectEstimator;
 use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Commands\InstallCommand as SpatieInstallCommand;
@@ -29,16 +29,8 @@ class SabHeroEstimatorServiceProvider extends PackageServiceProvider
                 'populate_estimator_settings_defaults',
             ])
             ->hasCommands([
-                InstallCommand::class,
-            ])
-            ->hasInstallCommand(function (SpatieInstallCommand $command) {
-                $command
-                    ->publishConfigFile()
-                    ->publishMigrations()
-                    ->publishAssets()
-                    ->askToRunMigrations()
-                    ->copyAndRegisterServiceProviderInApp();
-            });
+                SabHeroEstimatorInstallCommand::class,
+            ]);
     }
 
     public function packageRegistered(): void


### PR DESCRIPTION
### Summary of Changes

1. **Command Renaming and Consistency**:
   - Renamed the `InstallCommand` class to `SabHeroEstimatorInstallCommand` for consistency with the package naming convention.
   - Updated the command signature from `sab-hero-estimator:install` to `sabhero-estimator:install` in the README and source files for consistency.

2. **Asset Publishing**:
   - Added functionality to publish assets (images) to the configured disk during the installation process in the `SabHeroEstimatorInstallCommand`.

3. **Documentation Updates**:
   - Updated the README to reflect the new command signature and ensure all installation instructions are consistent with the changes made to the command class and signature.